### PR TITLE
Extract newsletter.js

### DIFF
--- a/index.php
+++ b/index.php
@@ -166,85 +166,18 @@ function newsletterConfirmation($newspages, $newspage_list, $subscribermail, $su
 
 function newsletterCreateForm($newspage_list, $subscribermail, $subscriberfield, $newspages) {
 
-    global $plugin_cf, $plugin_tx, $sn, $su, $hjs, $onload;
+    global $plugin_cf, $plugin_tx, $sn, $su, $hjs, $onload, $pth;
 
     $ptx = $plugin_tx['newsletter'];
 
     $o = '';
     $onload .= 'getFocus()';
-    $hjs .= '<script>
-    /* <![CDATA[ */
-    function getFocus() { 
-      document.getElementById("subscribermail").focus();
-    }
-    function addLoadEvent(func) { // for version before CMSimple_XH 1.2
-      var oldonload = window.onload;
-      if (typeof window.onload != "function") {
-        window.onload = func;
-      } else {
-        window.onload = function() {
-          if (oldonload) {
-            oldonload();
-          }
-          func();
-        }
-      }
-    }
-    addLoadEvent(function() {
-        getFocus();
-    });
-    
-        function hideFields(vfield) {
-        if (vfield.selectedIndex == 1) { 
-            document.getElementById(\'userinput\').style.display=\'none\';
-        } 
-        else {
-            document.getElementById(\'userinput\').style.display=\'block\';
-        }
-    }
-
-    function trim(stringToTrim) {
-        return stringToTrim.replace(/^\s+|\s+$/g,"");
-    }
-    
-    var busy=0;
-    function newsletter_EmptyField(field) {
-    if (busy) return;
-         busy=1;
-        if (trim(field.value)=="") {
-             field.style.backgroundColor ="#FFAEAE";
-            document.getElementById("err").innerHTML=\'' . $ptx['subscriber_fields_empty'].'\'; 
-          field.focus();
-          setTimeout("busy=0", 1);
-          return true;
-         }
-         else {
-             field.style.backgroundColor ="#FFFFFF";
-            document.getElementById("err").innerHTML="&nbsp;";
-          busy=0;
-          return false;
-        }  
-    }
-
-    function newsletter_ValidEmail(form){
-        if (busy) return;
-         busy=1;
-      var validRegExp = /^[^\s()<>@,;:\"\/\[\]?=]+@\w[\w-]*(\.\w[\w-]*)*\.[a-z]{2,}$/i;
-      if (form.subscribermail.value.search(validRegExp) == -1 ) {
-           document.getElementById("err").innerHTML="' . $ptx['subscriber_email_empty'].'";
-             form.subscribermail.style.backgroundColor ="#FFAEAE";
-             form.subscribermail.focus();
-             form.subscribermail.select();
-             setTimeout("busy=0", 1);
-        return false;
-      }
-        form.subscribermail.style.backgroundColor ="#FFFFFF"; 
-        document.getElementById(\'err\').innerHTML=\'&nbsp;\'; 
-        busy=0;
-    return true; 
-    }
-    /* ]]> */
-</script>';
+    $script = $pth['folder']['plugins'] . 'newsletter/newsletter.js';
+    $json = json_encode([
+        "fieldsEmpty" => $ptx['subscriber_fields_empty'],
+        "emailEmpty" => $ptx['subscriber_email_empty'],
+    ]);
+    $hjs .= '<script src="' . XH_hsc($script) . '" data-newsletter-i18n=\''. $json . '\'></script>';
     $o .= "\n"
         . '<form name="subscribe" id="subscribe" method="post" action="'
         . $sn
@@ -292,7 +225,7 @@ function newsletterCreateForm($newspage_list, $subscribermail, $subscriberfield,
         . (isset($_GET['uns'])
             ? newsletterConvert($_GET['uns'], 0)
             : $subscribermail)
-        . '" onblur="newsletter_ValidEmail(document.subscribe);">'
+        . '">'
         . '<br>'
         . "\n";
     $mandatory = (trim($ptx['subscriber_fields_mandatory']) != '');
@@ -311,7 +244,7 @@ function newsletterCreateForm($newspage_list, $subscribermail, $subscriberfield,
                          . '" type="text" class="newsletter_inputfield" value="'
                          . $subscriberfield[$i]
                          . ($mandatory
-                            ? '" onblur="newsletter_EmptyField(this);"'
+                            ? '" data-newsletter-mandatory'
                             : '"')
                          . '><br>'
                          . "\n";

--- a/index.php
+++ b/index.php
@@ -166,12 +166,11 @@ function newsletterConfirmation($newspages, $newspage_list, $subscribermail, $su
 
 function newsletterCreateForm($newspage_list, $subscribermail, $subscriberfield, $newspages) {
 
-    global $plugin_cf, $plugin_tx, $sn, $su, $hjs, $onload, $pth;
+    global $plugin_cf, $plugin_tx, $sn, $su, $hjs, $pth;
 
     $ptx = $plugin_tx['newsletter'];
 
     $o = '';
-    $onload .= 'getFocus()';
     $script = $pth['folder']['plugins'] . 'newsletter/newsletter.js';
     $json = json_encode([
         "fieldsEmpty" => $ptx['subscriber_fields_empty'],

--- a/newsletter.js
+++ b/newsletter.js
@@ -1,0 +1,85 @@
+function getFocus() { 
+    document.getElementById("subscribermail").focus();
+}
+function addLoadEvent(func) { // for version before CMSimple_XH 1.2
+    var oldonload = window.onload;
+    if (typeof window.onload != "function") {
+    window.onload = func;
+    } else {
+    window.onload = function() {
+        if (oldonload) {
+        oldonload();
+        }
+        func();
+    }
+    }
+}
+addLoadEvent(function() {
+    getFocus();
+});
+
+var newsletterI18n = JSON.parse(document.querySelector("script[data-newsletter-i18n]").dataset.newsletterI18n);
+
+    function hideFields(vfield) {
+    if (vfield.selectedIndex == 1) { 
+        document.getElementById('userinput').style.display='none';
+    } 
+    else {
+        document.getElementById('userinput').style.display='block';
+    }
+}
+
+function trim(stringToTrim) {
+    return stringToTrim.replace(/^\s+|\s+$/g,"");
+}
+
+var busy=0;
+function newsletter_EmptyField(field) {
+if (busy) return;
+        busy=1;
+    if (trim(field.value)=="") {
+            field.style.backgroundColor ="#FFAEAE";
+        document.getElementById("err").innerHTML=newsletterI18n.fieldsEmpty; 
+        field.focus();
+        setTimeout(function () {busy=0}, 1);
+        return true;
+        }
+        else {
+            field.style.backgroundColor ="#FFFFFF";
+        document.getElementById("err").innerHTML="&nbsp;";
+        busy=0;
+        return false;
+    }  
+}
+
+function newsletter_ValidEmail(form){
+    if (busy) return;
+        busy=1;
+    var validRegExp = /^[^\s()<>@,;:\"\/\[\]?=]+@\w[\w-]*(\.\w[\w-]*)*\.[a-z]{2,}$/i;
+    if (form.subscribermail.value.search(validRegExp) == -1 ) {
+        document.getElementById("err").innerHTML=newsletterI18n.emailEmpty;
+            form.subscribermail.style.backgroundColor ="#FFAEAE";
+            form.subscribermail.focus();
+            form.subscribermail.select();
+            setTimeout(function () {busy=0}, 1);
+    return false;
+    }
+    form.subscribermail.style.backgroundColor ="#FFFFFF"; 
+    document.getElementById('err').innerHTML='&nbsp;'; 
+    busy=0;
+return true; 
+}
+
+addEventListener("DOMContentLoaded", function () {
+    document.querySelectorAll('.newsletter_inputfield').forEach(function (input) {
+        if (input.id === 'subscribermail') {
+            input.onblur = function () {
+                newsletter_ValidEmail(document.subscribe);
+            };
+        } else if (input.dataset.newsletterMandatory !== undefined) {
+            input.onblur = function () {
+                newsletter_EmptyField(this);
+            };
+        }
+    });
+});

--- a/newsletter.js
+++ b/newsletter.js
@@ -1,21 +1,5 @@
-function getFocus() { 
+document.addEventListener("DOMContentLoaded", function () { 
     document.getElementById("subscribermail").focus();
-}
-function addLoadEvent(func) { // for version before CMSimple_XH 1.2
-    var oldonload = window.onload;
-    if (typeof window.onload != "function") {
-    window.onload = func;
-    } else {
-    window.onload = function() {
-        if (oldonload) {
-        oldonload();
-        }
-        func();
-    }
-    }
-}
-addLoadEvent(function() {
-    getFocus();
 });
 
 var newsletterI18n = JSON.parse(document.querySelector("script[data-newsletter-i18n]").dataset.newsletterI18n);


### PR DESCRIPTION
Instead of using an inline script, we move the JavaScript into its own file.  Since the script uses some language strings, we put them into a data- attribute of the script element, so that we can easily access the information from JavaScript.   We also do that to signal whether the subscriber fields are mandatory.

Note that so far we do not cater to the many deficiencies of the existing JS (most notably that the script introduces several global variables which are not even "namespaced"), nor do we cater to efficiency (the script should either be written to `$bjs` or defered).

Note also that the script now requires a somewhat contemporary browser, while previously it was supposed to work even in ES3 environments (e.g. IE 6).  If that is a concern, the script could be adapted.

---

@olape-git, this should be sufficient to prevent the script from failing to execute with `script-src 'self'`. The more reasonable solution nowadays would likely be to use HTML5 form validation (what would allow to drop almost all of the JS, and would fix the limited email regexp).